### PR TITLE
Only show the latest 30 events initially

### DIFF
--- a/lib/playlist_log/playlists/event.ex
+++ b/lib/playlist_log/playlists/event.ex
@@ -55,8 +55,24 @@ defmodule PlaylistLog.Playlists.Event do
     |> Enum.sort(&latest_first_order/2)
   end
 
-  defp latest_first_order({date1, _}, {date2, _}) do
+  def latest_first_order(%__MODULE__{timestamp: timestamp1}, %__MODULE__{timestamp: timestamp2}) do
+    latest_first_order(timestamp1, timestamp2)
+  end
+
+  def latest_first_order({%Date{} = date1, _}, {%Date{} = date2, _}) do
+    latest_first_order(date1, date2)
+  end
+
+  def latest_first_order(%Date{} = date1, %Date{} = date2) do
     case Date.compare(date1, date2) do
+      :lt -> false
+      :gt -> true
+      _ -> true
+    end
+  end
+
+  def latest_first_order(%DateTime{} = datetime1, %DateTime{} = datetime2) do
+    case DateTime.compare(datetime1, datetime2) do
       :lt -> false
       :gt -> true
       _ -> true

--- a/lib/playlist_log_web/live/log_live_view.ex
+++ b/lib/playlist_log_web/live/log_live_view.ex
@@ -5,6 +5,9 @@ defmodule PlaylistLogWeb.LogLiveView do
 
   require Logger
 
+  @initial_event_count 30
+  @more_events_increment 30
+
   def render(assigns) do
     PlaylistLogWeb.LogView.render("events.html", assigns)
   end
@@ -12,11 +15,13 @@ defmodule PlaylistLogWeb.LogLiveView do
   def mount(_params, session, socket) do
     events = Map.fetch!(session, "events")
     show_events = Map.fetch!(session, "show_events")
+    events_to_show = @initial_event_count
 
     assigns = [
+      events_to_show: events_to_show,
       events: events,
       show_events: show_events,
-      ordered_events: Event.filtered_events(events, show_events)
+      ordered_events: limited_filtered_events(events, show_events, events_to_show)
     ]
 
     {:ok, assign(socket, assigns), temporary_assigns: [ordered_events: []]}
@@ -25,8 +30,34 @@ defmodule PlaylistLogWeb.LogLiveView do
   def handle_event("event_filter_change", %{"show_events" => show_events}, socket) do
     Logger.debug("Event filter changed, showing #{show_events} events")
 
-    filtered_events = Event.filtered_events(socket.assigns[:events], show_events)
+    filtered_events =
+      limited_filtered_events(
+        socket.assigns[:events],
+        show_events,
+        socket.assigns[:events_to_show]
+      )
 
     {:noreply, assign(socket, show_events: show_events, ordered_events: filtered_events)}
+  end
+
+  def handle_event("show_more_events", _, socket) do
+    Logger.debug("Loading #{@more_events_increment} more events...")
+    events_to_show = socket.assigns[:events_to_show] + @more_events_increment
+
+    filtered_events =
+      limited_filtered_events(
+        socket.assigns[:events],
+        socket.assigns[:show_events],
+        events_to_show
+      )
+
+    {:noreply, assign(socket, events_to_show: events_to_show, ordered_events: filtered_events)}
+  end
+
+  defp limited_filtered_events(events, filter, limit) do
+    events
+    |> Enum.sort(&Event.latest_first_order/2)
+    |> Enum.take(limit)
+    |> Event.filtered_events(filter)
   end
 end

--- a/lib/playlist_log_web/templates/log/events.html.leex
+++ b/lib/playlist_log_web/templates/log/events.html.leex
@@ -27,3 +27,9 @@
     render("date_events.html", date: date, events: events)
 end %>
 </div>
+
+<div class="row">
+    <div class="column column-offset-25">
+        <button phx-click="show_more_events" >Show more changes</button>
+    </div>
+</div>

--- a/test/playlist_log/repo_test.exs
+++ b/test/playlist_log/repo_test.exs
@@ -1,0 +1,133 @@
+defmodule PlaylistLog.RepoTest do
+  use ExUnit.Case
+
+  alias PlaylistLog.Repo
+  alias PlaylistLog.Playlists.Event
+  alias PlaylistLog.Playlists.Log
+  alias PlaylistLog.Playlists.Track
+
+  @event_time_stamp DateTime.from_naive!(~N[2020-05-10T13:37:00Z], "Etc/UTC")
+  @event_log_id "event-logid-1"
+
+  setup do
+    CubDB.delete(:cubdb, Repo.key(Event, {@event_log_id, @event_time_stamp}))
+  end
+
+  describe "insert/3" do
+    test "saves Log struct as map" do
+      user_id = "user031"
+
+      log = %Log{
+        id: "daLog123",
+        name: "foo",
+        description: "",
+        track_count: 0,
+        external_id: "id",
+        collaborative: false,
+        owner_id: user_id,
+        tracks: [%Track{name: "ye", uri: "uri", id: "id"}]
+      }
+
+      :ok = Repo.insert(Log, user_id, [log])
+
+      log_from_storage = CubDB.get(:cubdb, Repo.key(Log, {user_id, log.id}))
+      refute Map.has_key?(log_from_storage, :__struct__)
+    end
+
+    test "saves Event struct as map" do
+      user_id = "user031-2"
+
+      event = %Event{
+        log_id: @event_log_id,
+        timestamp: @event_time_stamp,
+        type: "TRACK_ADDED",
+        user: user_id,
+        track_uri: "uri",
+        track_name: "name",
+        track_artist: "artist"
+      }
+
+      :ok = Repo.insert(Event, event.log_id, event)
+
+      [event_from_storage] = CubDB.get(:cubdb, Repo.key(Event, {event.log_id, @event_time_stamp}))
+
+      refute Map.has_key?(event_from_storage, :__struct__)
+    end
+  end
+
+  describe "get/2" do
+    test "can read Log when stored as map" do
+      user_id = "user1"
+
+      log = %Log{
+        name: "foo",
+        description: "",
+        track_count: 0,
+        external_id: "id",
+        collaborative: false,
+        owner_id: user_id
+      }
+
+      :ok = CubDB.put(:cubdb, Repo.key(Log, {user_id, "log_as_map"}), Map.from_struct(log))
+      :ok = CubDB.put(:cubdb, Repo.key(Log, {user_id, "log_as_struct"}), log)
+
+      {:ok, log_from_struct} = Repo.get(Log, {user_id, "log_as_struct"})
+      {:ok, log_from_map} = Repo.get(Log, {user_id, "log_as_map"})
+
+      assert log_from_map == log_from_struct
+    end
+  end
+
+  describe "all/2" do
+    test "can read Logs stored as maps" do
+      user_id = "user2"
+
+      log = %Log{
+        name: "foo",
+        description: "",
+        track_count: 0,
+        external_id: "id",
+        collaborative: false,
+        owner_id: user_id
+      }
+
+      :ok = CubDB.put(:cubdb, Repo.key(Log, {user_id, "Log_as_map1"}), Map.from_struct(log))
+      :ok = CubDB.put(:cubdb, Repo.key(Log, {user_id, "Log_as_map2"}), Map.from_struct(log))
+
+      {:ok, result} = Repo.all(Log, user_id)
+      assert result == [log, log]
+    end
+
+    test "can read Events stored as maps" do
+      log_id = "log_with_map_events"
+
+      events = [
+        %Event{
+          log_id: log_id,
+          timestamp: DateTime.utc_now(),
+          type: "TRACK_REMOVED",
+          user: "usr",
+          track_uri: "uri",
+          track_name: "tn",
+          track_artist: "ta"
+        },
+        %Event{
+          log_id: log_id,
+          timestamp: DateTime.utc_now(),
+          type: "TRACK_ADDED",
+          user: "usr",
+          track_uri: "uri2",
+          track_name: "tn2",
+          track_artist: "ta2"
+        }
+      ]
+
+      event_maps = Enum.map(events, &Map.from_struct/1)
+      key = Repo.key(Event, {log_id, DateTime.to_date(hd(events).timestamp)})
+      :ok = CubDB.put(:cubdb, key, event_maps)
+
+      {:ok, result} = Repo.all(Event, log_id)
+      assert Enum.sort(result) == Enum.sort(events)
+    end
+  end
+end


### PR DESCRIPTION
Allow user to load more events (in 30 increments) with a button underneath the timeline

Implements #15 sort of. This change does not really lower the memory footprint, all events are still loaded into memory. This is only a cosmetic change.