### PR TITLE
Limit events to 30 on initial playlist load

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -18,7 +18,9 @@ config :playlist_log, PlaylistLogWeb.Endpoint,
   ]
 
 # Path.join(:code.priv_dir(:playlist_log), "cubdb")
-config :playlist_log, PlaylistLog.Repo, data_dir: "priv/cubdb"
+config :playlist_log, PlaylistLog.Repo,
+  data_dir: "priv/cubdb",
+  auto_compact: true
 
 config :playlist_log, PlaylistLog.Playlists, spotify_client: PlaylistLog.Spotify
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -9,6 +9,8 @@ config :playlist_log, PlaylistLogWeb.Endpoint,
 # Print only warnings and errors during test
 config :logger, level: :warn
 
-config :playlist_log, PlaylistLog.Repo, data_dir: "priv/cubdb_test"
+config :playlist_log, PlaylistLog.Repo,
+  data_dir: "priv/cubdb_test",
+  auto_compact: false
 
 config :playlist_log, PlaylistLog.Playlists, spotify_client: PlaylistLog.Test.SpotifyStubClient

--- a/lib/playlist_log/application.ex
+++ b/lib/playlist_log/application.ex
@@ -11,7 +11,11 @@ defmodule PlaylistLog.Application do
     children = [
       {ConCache,
        [name: :track_cache, ttl_check_interval: :timer.minutes(1), global_ttl: :timer.minutes(30)]},
-      CubDB.child_spec(data_dir: @cubdb_data_dir, auto_compact: true, name: :cubdb),
+      CubDB.child_spec(
+        data_dir: @cubdb_data_dir,
+        auto_compact: Application.get_env(:playlist_log, PlaylistLog.Repo)[:auto_compact],
+        name: :cubdb
+      ),
       {Phoenix.PubSub, name: PlaylistLog.PubSub},
       PlaylistLogWeb.Endpoint
     ]

--- a/lib/playlist_log/playlists.ex
+++ b/lib/playlist_log/playlists.ex
@@ -67,9 +67,10 @@ defmodule PlaylistLog.Playlists do
       {:error, {:no_such_resource, {"octavorce", -1}}}
 
   """
-  def get_log(user, log_id, access_token) do
+  def get_log(user, log_id, access_token, opts \\ []) do
     with {:ok, user_id} <- Map.fetch(user, "id"),
-         {:ok, log} <- Repo.get(Log, {user_id, log_id}),
+         {:ok, log} <- Repo.get(Log, {user_id, log_id}, opts),
+         _ <- IO.inspect(length(log.events), label: "events from storage"),
          {:ok, raw_tracks} <- spotify().get_playlist_tracks(access_token, log_id),
          tracks <- Enum.map(raw_tracks, &Track.new/1),
          {unique_events, missing_events} <- unique_events(log_id, tracks, log.events),

--- a/lib/playlist_log/playlists.ex
+++ b/lib/playlist_log/playlists.ex
@@ -70,7 +70,6 @@ defmodule PlaylistLog.Playlists do
   def get_log(user, log_id, access_token, opts \\ []) do
     with {:ok, user_id} <- Map.fetch(user, "id"),
          {:ok, log} <- Repo.get(Log, {user_id, log_id}, opts),
-         _ <- IO.inspect(length(log.events), label: "events from storage"),
          {:ok, raw_tracks} <- spotify().get_playlist_tracks(access_token, log_id),
          tracks <- Enum.map(raw_tracks, &Track.new/1),
          {unique_events, missing_events} <- unique_events(log_id, tracks, log.events),

--- a/lib/playlist_log_web/controllers/log_controller.ex
+++ b/lib/playlist_log_web/controllers/log_controller.ex
@@ -46,8 +46,10 @@ defmodule PlaylistLogWeb.LogController do
     show_events = Map.get(params, "show_events", "all")
     spotify_user = get_session(conn, :spotify_user)
     spotify_access_token = conn.cookies["spotify_access_token"]
+    event_count = Map.get(params, "max_events", 30)
+    opts = [max_events: event_count]
 
-    with {:ok, log} <- Playlists.get_log(spotify_user, id, spotify_access_token),
+    with {:ok, log} <- Playlists.get_log(spotify_user, id, spotify_access_token, opts),
          ordered_tracks <- Enum.sort(log.tracks, &latest_first_order/2) do
       render(conn, "show.html",
         log: log,

--- a/lib/playlist_log_web/live/log_live_view.ex
+++ b/lib/playlist_log_web/live/log_live_view.ex
@@ -47,21 +47,22 @@ defmodule PlaylistLogWeb.LogLiveView do
     Logger.debug("Loading #{@more_events_increment} more events for log #{log_id} ...")
     events_to_show = socket.assigns[:events_to_show] + @more_events_increment
 
-    with {:ok, events} <- PlaylistLog.Repo.all(Event, log_id, max_events: events_to_show) do
-      filtered_events =
-        limited_filtered_events(
-          events,
-          socket.assigns[:show_events],
-          events_to_show
-        )
+    case PlaylistLog.Repo.all(Event, log_id, max_events: events_to_show) do
+      {:ok, events} ->
+        filtered_events =
+          limited_filtered_events(
+            events,
+            socket.assigns[:show_events],
+            events_to_show
+          )
 
-      {:noreply,
-       assign(socket,
-         events: events,
-         events_to_show: events_to_show,
-         ordered_events: filtered_events
-       )}
-    else
+        {:noreply,
+         assign(socket,
+           events: events,
+           events_to_show: events_to_show,
+           ordered_events: filtered_events
+         )}
+
       unexpected ->
         Logger.error(
           "Unexpected response when loading events for log #{log_id}: #{inspect(unexpected)}"

--- a/lib/playlist_log_web/live/log_live_view.ex
+++ b/lib/playlist_log_web/live/log_live_view.ex
@@ -15,11 +15,13 @@ defmodule PlaylistLogWeb.LogLiveView do
   def mount(_params, session, socket) do
     events = Map.fetch!(session, "events")
     show_events = Map.fetch!(session, "show_events")
+    log_id = Map.fetch!(session, "log_id")
     events_to_show = @initial_event_count
 
     assigns = [
       events_to_show: events_to_show,
       events: events,
+      log_id: log_id,
       show_events: show_events,
       ordered_events: limited_filtered_events(events, show_events, events_to_show)
     ]
@@ -41,22 +43,38 @@ defmodule PlaylistLogWeb.LogLiveView do
   end
 
   def handle_event("show_more_events", _, socket) do
-    Logger.debug("Loading #{@more_events_increment} more events...")
+    log_id = socket.assigns[:log_id]
+    Logger.debug("Loading #{@more_events_increment} more events for log #{log_id} ...")
     events_to_show = socket.assigns[:events_to_show] + @more_events_increment
 
-    filtered_events =
-      limited_filtered_events(
-        socket.assigns[:events],
-        socket.assigns[:show_events],
-        events_to_show
-      )
+    with {:ok, events} <- PlaylistLog.Repo.all(Event, log_id, max_events: events_to_show) do
+      filtered_events =
+        limited_filtered_events(
+          events,
+          socket.assigns[:show_events],
+          events_to_show
+        )
 
-    {:noreply, assign(socket, events_to_show: events_to_show, ordered_events: filtered_events)}
+      {:noreply,
+       assign(socket,
+         events: events,
+         events_to_show: events_to_show,
+         ordered_events: filtered_events
+       )}
+    else
+      unexpected ->
+        Logger.error(
+          "Unexpected response when loading events for log #{log_id}: #{inspect(unexpected)}"
+        )
+
+        {:noreply, socket}
+    end
   end
 
   defp limited_filtered_events(events, filter, limit) do
     events
     |> Enum.sort(&Event.latest_first_order/2)
+    |> IO.inspect(label: "sorted #{length(events)} events")
     |> Enum.take(limit)
     |> Event.filtered_events(filter)
   end

--- a/lib/playlist_log_web/live/log_live_view.ex
+++ b/lib/playlist_log_web/live/log_live_view.ex
@@ -74,7 +74,6 @@ defmodule PlaylistLogWeb.LogLiveView do
   defp limited_filtered_events(events, filter, limit) do
     events
     |> Enum.sort(&Event.latest_first_order/2)
-    |> IO.inspect(label: "sorted #{length(events)} events")
     |> Enum.take(limit)
     |> Event.filtered_events(filter)
   end

--- a/lib/playlist_log_web/templates/log/events.html.leex
+++ b/lib/playlist_log_web/templates/log/events.html.leex
@@ -1,4 +1,4 @@
-<h3 badge="<%= length(@events) %>">Changes</h3>
+<h3>Changes</h3>
 
 <form phx-change="event_filter_change">
 <fieldset>

--- a/lib/playlist_log_web/templates/log/show.html.eex
+++ b/lib/playlist_log_web/templates/log/show.html.eex
@@ -45,7 +45,7 @@
   </div>
 
   <div class="column column-40">
-    <%= live_render(@conn, PlaylistLogWeb.LogLiveView, session: %{"show_events" => @show_events, "events" => @log.events}) %>
+    <%= live_render(@conn, PlaylistLogWeb.LogLiveView, session: %{"log_id" => @log.id, "show_events" => @show_events, "events" => @log.events}) %>
   </div>
 </div>
 

--- a/test/playlist_log_web/controllers/log_controller_test.exs
+++ b/test/playlist_log_web/controllers/log_controller_test.exs
@@ -7,20 +7,6 @@ defmodule PlaylistLogWeb.LogControllerTest do
   alias PlaylistLog.Playlists.Track
   alias PlaylistLog.Repo
 
-  setup_all do
-    path = Application.get_env(:playlist_log, PlaylistLog.Repo)[:data_dir]
-
-    with {:ok, files} <- File.ls(path) do
-      Enum.each(files, fn file ->
-        full_path = Path.join(path, file)
-        IO.puts("Deleting file: #{full_path}")
-        File.rm(full_path)
-      end)
-    end
-
-    :ok
-  end
-
   describe "add_track/2" do
     test "remove_oldest", %{conn: conn} do
       log_id = "test-remove-oldest-track"

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,11 @@
 ExUnit.start()
 Application.ensure_all_started(:bypass)
+path = Application.get_env(:playlist_log, PlaylistLog.Repo)[:data_dir]
+
+with {:ok, files} <- File.ls(path) do
+  Enum.each(files, fn file ->
+    full_path = Path.join(path, file)
+    IO.puts("Deleting file: #{full_path}")
+    File.rm(full_path)
+  end)
+end


### PR DESCRIPTION
The page gets very long with past events that may not be that relevant. You can still load more if needed. 30 initial events seems reasonable.