### PR TITLE
Handle invalid spotify URI, fix #27

### DIFF
--- a/lib/playlist_log/music_client.ex
+++ b/lib/playlist_log/music_client.ex
@@ -24,4 +24,7 @@ defmodule PlaylistLog.MusicClient do
               playlist_id :: String.t(),
               track_uris :: list(String.t())
             ) :: {:ok, String.t()} | {:error, {Module.t(), any}}
+
+  @callback validate_uri(maybe_uri :: String.t()) ::
+              {:ok, :track | :album | :artist} | {:error, :invalid_format}
 end

--- a/lib/playlist_log/playlists.ex
+++ b/lib/playlist_log/playlists.ex
@@ -208,7 +208,8 @@ defmodule PlaylistLog.Playlists do
   end
 
   def add_track(%Log{} = log, track_uri, access_token) do
-    with {:ok, raw_track} <- spotify().get_track(track_uri, access_token),
+    with {:ok, :track} <- spotify().validate_uri(track_uri),
+         {:ok, raw_track} <- spotify().get_track(track_uri, access_token),
          {:ok, new_snapshot_id} <-
            spotify().add_tracks_to_playlist(access_token, log.id, [track_uri]),
          changeset <-

--- a/lib/playlist_log/spotify.ex
+++ b/lib/playlist_log/spotify.ex
@@ -147,6 +147,25 @@ defmodule PlaylistLog.Spotify do
     end)
   end
 
+  @doc """
+  Checks if a string is a valid spotify uri.
+
+  Example of valid uris:
+
+    spotify:album:27ftYHLeunzcSzb33Wk1hf
+    spotify:artist:3mvkWMe6swnknwscwvGCHO
+    spotify:track:7lEptt4wbM0yJTvSG5EBof
+  """
+  @impl PlaylistLog.MusicClient
+  def validate_uri(maybe_uri) do
+    case String.split(maybe_uri, ":", parts: 3) do
+      ["spotify", "track", _id] -> {:ok, :track}
+      ["spotify", "album", _id] -> {:ok, :album}
+      ["spotify", "artist", _id] -> {:ok, :artist}
+      _ -> {:error, :invalid_format}
+    end
+  end
+
   defp handle_unexpected_response(url, {:ok, %HTTPoison.Response{status_code: 429, body: body}}) do
     Logger.info("Hit spotify rate-limit (429) for #{url}")
     {:error, {__MODULE__, Jason.decode!(body)}}

--- a/lib/playlist_log_web/controllers/log_controller.ex
+++ b/lib/playlist_log_web/controllers/log_controller.ex
@@ -27,6 +27,7 @@ defmodule PlaylistLogWeb.LogController do
 
   def index(conn, _params) do
     spotify_user = get_session(conn, :spotify_user)
+
     # spotify_access_token = conn.cookies["spotify_access_token"]
 
     case Playlists.list_logs(spotify_user) do
@@ -123,6 +124,21 @@ defmodule PlaylistLogWeb.LogController do
 
         conn
         |> put_flash(:error, "Unable to remove the oldest track")
+        |> redirect(to: Routes.log_path(conn, :show, log_id))
+
+      {:ok, :album} ->
+        conn
+        |> put_flash(:error, "Can't add an album to the list")
+        |> redirect(to: Routes.log_path(conn, :show, log_id))
+
+      {:ok, :artist} ->
+        conn
+        |> put_flash(:error, "Can't add an artist to the list")
+        |> redirect(to: Routes.log_path(conn, :show, log_id))
+
+      {:error, :invalid_format} ->
+        conn
+        |> put_flash(:error, "Invalid spotify uri")
         |> redirect(to: Routes.log_path(conn, :show, log_id))
     end
   end

--- a/test/playlist_log/spotify_test.exs
+++ b/test/playlist_log/spotify_test.exs
@@ -1,0 +1,17 @@
+defmodule PlaylistLog.SpotifyTest do
+  use ExUnit.Case
+
+  alias PlaylistLog.Spotify
+
+  describe "validate_uri/1" do
+    test "returns {:ok, :track} for valid track uri" do
+      uri = "spotify:track:7lEptt4wbM0yJTvSG5EBof"
+      assert {:ok, :track} == Spotify.validate_uri(uri)
+    end
+
+    test "returns {:error, :invalid_format} for invalid uri" do
+      uri = "https://www.google.com/track/1234"
+      assert {:error, :invalid_format} == Spotify.validate_uri(uri)
+    end
+  end
+end

--- a/test/playlist_log_web/controllers/log_controller_test.exs
+++ b/test/playlist_log_web/controllers/log_controller_test.exs
@@ -36,7 +36,8 @@ defmodule PlaylistLogWeb.LogControllerTest do
         get_playlist_tracks: spotify_tracks(log.tracks),
         get_track: spotify_track(add_track_params["uri"]),
         add_tracks_to_playlist: fn _, _, _ -> {:ok, "snapshot2"} end,
-        delete_tracks_from_playlist: fn _, _, "snapshot2", _ -> {:ok, "snapshot3"} end do
+        delete_tracks_from_playlist: fn _, _, "snapshot2", _ -> {:ok, "snapshot3"} end,
+        validate_uri: fn _ -> {:ok, :track} end do
         conn =
           conn
           |> assign(:spotify, :no_refresh)

--- a/test/support/spotify_stub_client.ex
+++ b/test/support/spotify_stub_client.ex
@@ -212,6 +212,11 @@ defmodule PlaylistLog.Test.SpotifyStubClient do
     {:ok, String.reverse(playlist_id)}
   end
 
+  @impl PlaylistLog.MusicClient
+  def validate_uri(_uri) do
+    {:ok, :track}
+  end
+
   @get_track_response """
   {
     "album": {


### PR DESCRIPTION
Show an error to the user (with a flash), rather than crash on invalid spotify track uri input.