### PR TITLE
Accept spotify links in addition to URIs

### DIFF
--- a/lib/playlist_log/music_client.ex
+++ b/lib/playlist_log/music_client.ex
@@ -25,6 +25,6 @@ defmodule PlaylistLog.MusicClient do
               track_uris :: list(String.t())
             ) :: {:ok, String.t()} | {:error, {Module.t(), any}}
 
-  @callback validate_uri(maybe_uri :: String.t()) ::
-              {:ok, :track | :album | :artist} | {:error, :invalid_format}
+  @callback validate_track_link(maybe_link :: String.t()) ::
+              {:ok, String.t()} | {:error, any()}
 end

--- a/lib/playlist_log/playlists.ex
+++ b/lib/playlist_log/playlists.ex
@@ -211,7 +211,7 @@ defmodule PlaylistLog.Playlists do
   end
 
   def add_track(%Log{} = log, track_uri, access_token) do
-    with {:ok, :track} <- spotify().validate_uri(track_uri),
+    with {:ok, track_uri} <- spotify().validate_track_link(track_uri),
          {:ok, raw_track} <- spotify().get_track(track_uri, access_token),
          {:ok, new_snapshot_id} <-
            spotify().add_tracks_to_playlist(access_token, log.id, [track_uri]),

--- a/test/playlist_log/spotify_test.exs
+++ b/test/playlist_log/spotify_test.exs
@@ -4,14 +4,22 @@ defmodule PlaylistLog.SpotifyTest do
   alias PlaylistLog.Spotify
 
   describe "validate_uri/1" do
-    test "returns {:ok, :track} for valid track uri" do
+    test "returns {:ok, {:track, uri}} for valid track uri" do
       uri = "spotify:track:7lEptt4wbM0yJTvSG5EBof"
-      assert {:ok, :track} == Spotify.validate_uri(uri)
+      assert {:ok, {:track, uri}} == Spotify.validate_uri(uri)
     end
 
     test "returns {:error, :invalid_format} for invalid uri" do
       uri = "https://www.google.com/track/1234"
       assert {:error, :invalid_format} == Spotify.validate_uri(uri)
+    end
+  end
+
+  describe "validate_link/1" do
+    test "returns {:ok, track} for valid track link" do
+      link = "https://open.spotify.com/track/2azLsNFfIPtxNU4QmJzPow?si=85f957ef77854352"
+      uri = "spotify:track:2azLsNFfIPtxNU4QmJzPow"
+      assert {:ok, uri} == Spotify.validate_link(link)
     end
   end
 end

--- a/test/playlist_log_web/controllers/log_controller_test.exs
+++ b/test/playlist_log_web/controllers/log_controller_test.exs
@@ -37,7 +37,7 @@ defmodule PlaylistLogWeb.LogControllerTest do
         get_track: spotify_track(add_track_params["uri"]),
         add_tracks_to_playlist: fn _, _, _ -> {:ok, "snapshot2"} end,
         delete_tracks_from_playlist: fn _, _, "snapshot2", _ -> {:ok, "snapshot3"} end,
-        validate_uri: fn _ -> {:ok, :track} end do
+        validate_track_link: fn link -> {:ok, link} end do
         conn =
           conn
           |> assign(:spotify, :no_refresh)

--- a/test/support/spotify_stub_client.ex
+++ b/test/support/spotify_stub_client.ex
@@ -213,8 +213,8 @@ defmodule PlaylistLog.Test.SpotifyStubClient do
   end
 
   @impl PlaylistLog.MusicClient
-  def validate_uri(_uri) do
-    {:ok, :track}
+  def validate_track_link(uri) do
+    {:ok, uri}
   end
 
   @get_track_response """


### PR DESCRIPTION
Example link: `https://open.spotify.com/track/0ZCO7hSGaDx6trifq7fKQe?si=04a2a7c0c8c34385`

The reason is because of a recent update to the official desktop client.
It is no longer trivial to get the uri for a song.

Fixes #40 